### PR TITLE
Disabled default features for reqwest to allow overriding the TLS backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,5 +14,5 @@ serde_json = "^1.0"
 serde_repr = "^0.1"
 url = "^2.5"
 uuid = { version = "^1.8", features = ["serde", "v4"] }
-reqwest = { version = "^0.12", features = ["json", "multipart"] }
+reqwest = { version = "^0.12", default-features = false, features = ["json", "multipart"] }
 reqwest-middleware = { version = "^0.3", features = ["json", "multipart"] }


### PR DESCRIPTION
Hi! I tried building my project with authentik-client added and for the life of me I couldn't switch the `reqwest` TLS backend to `rustls` instead of `native-tls` (to build my project in a very stripped-down environment). 

From the [reqwest docs](https://docs.rs/reqwest/latest/reqwest/tls/index.html):
> **default-tls**
> 
> reqwest will pick a TLS backend by default. This is true when the default-tls feature is enabled.
> While it currently uses native-tls, [...]
> This feature is enabled by default, and takes precedence if any other crate enables it.
> Since Cargo features are additive, other crates in your dependency tree can cause the default backend to be enabled.