### PR TITLE
Update the generator versions to generate better reqwest dependencies

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,14 +14,14 @@ build:
 	docker run --rm \
 		-v "${PWD}:/local" \
 		--user "${UID}:${GID}" \
-		docker.io/openapitools/openapi-diff:2.1.0-beta.11 \
+		docker.io/openapitools/openapi-diff:2.1.2 \
 		--markdown /local/diff.test \
 		/local/schema-old.yml /local/schema.yml || echo > diff.test
 	rm schema-old.yml
 	docker run --rm \
 		-v "${PWD}:/local" \
 		--user "${UID}:${GID}" \
-		docker.io/openapitools/openapi-generator-cli:v7.8.0 \
+		docker.io/openapitools/openapi-generator-cli:v7.14.0 \
 		generate \
 		-i /local/schema.yml \
 		-g rust \


### PR DESCRIPTION
Resolves #1 in the "right way" I think.

Running it locally:
<img width="699" height="996" alt="image" src="https://github.com/user-attachments/assets/05039fe9-1135-4837-b114-0b76e8b4750f" />


Gets the output desired, and a whole lot of other stuff, that I assume is correct :)